### PR TITLE
Add jjwf plugin with jj workflow commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,16 @@
       "source": "./plugins/jj-vcs"
     },
     {
+      "name": "jjwf",
+      "description": "Jujutsu workflow commands: /ci, /describe, /squash, /catchup, /clone, /pr",
+      "version": "0.1.0",
+      "author": {
+        "name": "schpet"
+      },
+      "homepage": "https://github.com/schpet/toolbox",
+      "source": "./plugins/jjwf"
+    },
+    {
       "name": "changelog",
       "description": "Manage project changelogs following the Keep a Changelog format",
       "version": "0.1.7",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ a dumping ground for teaching the llm new tricks.
 | Plugin | Description |
 |--------|-------------|
 | **[jj-vcs](plugins/jj-vcs/README.md)** | Jujutsu (jj) version control documentation and workflows |
+| **[jjwf](plugins/jjwf/README.md)** | Jujutsu workflow commands: `/ci`, `/describe`, `/squash`, `/catchup`, `/clone`, `/pr` |
 | **changelog** | Manage project changelogs following the [Keep a Changelog](https://keepachangelog.com) format |
 | **svbump** | Read and write semantic versions in config files (JSON, TOML, YAML) |
 | **chores** | Jujutsu repository maintenance and Apple container utilities |
@@ -32,6 +33,7 @@ claude plugin marketplace add schpet/toolbox
 
 ```bash
 claude plugin install jj-vcs@toolbox
+claude plugin install jjwf@toolbox
 claude plugin install changelog@toolbox
 claude plugin install svbump@toolbox
 claude plugin install chores@toolbox
@@ -44,6 +46,7 @@ Restart Claude Code after installation.
 
 ```bash
 claude plugin install jj-vcs@toolbox
+claude plugin install jjwf@toolbox
 claude plugin install changelog@toolbox
 claude plugin install svbump@toolbox
 claude plugin install chores@toolbox

--- a/justfile
+++ b/justfile
@@ -10,6 +10,7 @@ generate-jj-docs:
 # Remove local plugin installation
 claude-remove-local:
     -claude plugin remove jj-vcs@toolbox
+    -claude plugin remove jjwf@toolbox
     -claude plugin remove changelog@toolbox
     -claude plugin remove svbump@toolbox
     -claude plugin remove chores@toolbox
@@ -20,6 +21,7 @@ claude-remove-local:
 claude-install-local:
     claude plugin marketplace add ./
     claude plugin install jj-vcs@toolbox
+    claude plugin install jjwf@toolbox
     claude plugin install changelog@toolbox
     claude plugin install svbump@toolbox
     claude plugin install chores@toolbox
@@ -31,6 +33,7 @@ claude-reinstall-local: claude-remove-local claude-install-local
 # Update plugins (reinstall)
 claude-update:
     claude plugin install jj-vcs@toolbox
+    claude plugin install jjwf@toolbox
     claude plugin install changelog@toolbox
     claude plugin install svbump@toolbox
     claude plugin install chores@toolbox
@@ -53,6 +56,7 @@ bump-versions:
 claude-install-github:
     claude plugin marketplace add schpet/toolbox
     claude plugin install jj-vcs@toolbox
+    claude plugin install jjwf@toolbox
     claude plugin install changelog@toolbox
     claude plugin install svbump@toolbox
     claude plugin install chores@toolbox

--- a/plugins/chores/commands/gist.md
+++ b/plugins/chores/commands/gist.md
@@ -1,0 +1,34 @@
+---
+description: Create a secret GitHub gist from provided content
+---
+
+# Gist
+
+Create a secret GitHub gist from the provided content using the gh CLI.
+
+## Usage
+
+The user provides content (code, text, notes, etc.) as an argument to this command.
+
+## Workflow
+
+1. Take the content provided by the user
+
+2. Create a unique temp file and write content to it:
+   ```bash
+   mktemp -t gist.md
+   ```
+   This returns a path like `/var/folders/.../gist.md.XXXXXX`. Use the Write tool to write the user's content to this path.
+
+3. Create a secret gist using the gh CLI (gists are secret by default):
+   ```bash
+   gh gist create <temp-file-path>
+   ```
+
+4. Report the gist URL to the user (the temp file persists for reference)
+
+## Notes
+
+- Gists are created as **secret** by default (no flag needed)
+- The gh CLI must be authenticated (`gh auth status` to check)
+- If the user wants a public gist, add `-p` or `--public` flag

--- a/plugins/jjwf/.claude-plugin/plugin.json
+++ b/plugins/jjwf/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "jjwf",
+  "description": "Jujutsu (jj) workflow commands for Claude Code - commit, describe, squash",
+  "version": "0.1.0",
+  "author": {
+    "name": "schpet"
+  },
+  "homepage": "https://github.com/schpet/toolbox"
+}

--- a/plugins/jjwf/README.md
+++ b/plugins/jjwf/README.md
@@ -1,0 +1,23 @@
+# jjwf
+
+Jujutsu (jj) workflow commands for Claude Code.
+
+## Installation
+
+```bash
+claude plugin marketplace add schpet/toolbox
+claude plugin install jjwf@toolbox
+```
+
+## Commands
+
+- `/ci` - Commit with auto-generated message
+- `/describe` - Update description (preserves ID prefixes and trailers)
+- `/squash` - Squash into parent
+- `/catchup` - Fetch and rebase onto trunk
+- `/clone <url>` - Clone repo and track default bookmark
+- `/pr` - Clean up mutable commits and create a pull request
+
+## Related
+
+- **[jj-vcs](../jj-vcs/README.md)** - Comprehensive jj documentation

--- a/plugins/jjwf/commands/catchup.md
+++ b/plugins/jjwf/commands/catchup.md
@@ -1,0 +1,32 @@
+---
+description: Fetch from remote and rebase onto trunk
+---
+
+# Catchup
+
+Fetch the latest changes from the remote and rebase the current change onto the trunk branch.
+
+## Workflow
+
+1. **Fetch from the remote**:
+   ```bash
+   jj git fetch
+   ```
+
+2. **Rebase onto trunk**:
+   ```bash
+   jj rebase -d trunk()
+   ```
+
+   The `trunk()` revset is a built-in jj alias that automatically resolves to the head commit of the default bookmark (typically `main` or `master`) on the default remote (`origin` or `upstream`).
+
+3. **Show the result**:
+   ```bash
+   jj log -r '::@' --limit 10
+   ```
+
+## Notes
+
+- The `trunk()` revset handles the detection of the main/master/trunk branch automatically
+- If there are conflicts after rebasing, inform the user and show them with `jj status`
+- If the fetch fails (e.g., no network), report the error and don't attempt the rebase

--- a/plugins/jjwf/commands/ci.md
+++ b/plugins/jjwf/commands/ci.md
@@ -1,0 +1,38 @@
+---
+description: Commit the current jj change with an auto-generated description
+---
+
+# CI (Commit)
+
+Commit the current jj change by generating a description from the diff and running `jj ci -m`.
+
+## Workflow
+
+1. **Get the current diff**:
+   ```bash
+   jj diff --git
+   ```
+
+2. **Generate a commit message** based on the diff:
+   - Summarize what changed in a clear, concise message
+   - Use imperative mood (e.g., "Add feature" not "Added feature")
+   - First line should be a brief summary (50 chars or less if possible)
+   - If more detail is needed, add a blank line followed by a body
+
+3. **Commit the change**:
+   ```bash
+   jj ci -m "Your generated message"
+   ```
+
+   Note: `jj ci` is an alias for `jj commit`. It commits the current change and creates a new empty change on top.
+
+4. **Show the result**:
+   ```bash
+   jj log -r @- --ignore-working-copy
+   ```
+
+## Notes
+
+- If the diff is empty, inform the user there's nothing to commit
+- The `-m` flag is required to avoid opening an editor
+- After `jj ci`, the working copy (`@`) will be a new empty change, and the committed change is at `@-`

--- a/plugins/jjwf/commands/clone.md
+++ b/plugins/jjwf/commands/clone.md
@@ -1,0 +1,72 @@
+---
+description: Clone a Git repository with jj and track the default bookmark
+---
+
+# Clone
+
+Clone a Git repository using jj and set up tracking for the default bookmark (main/master).
+
+## Usage
+
+```
+/clone <repo-url>
+```
+
+The repo URL can be:
+- A GitHub URL: `https://github.com/owner/repo`
+- A Git URL: `https://github.com/owner/repo.git`
+- An SSH URL: `git@github.com:owner/repo.git`
+
+## Workflow
+
+1. **Clone the repository**:
+   ```bash
+   jj git clone <repo-url>
+   ```
+
+   This creates a colocated jj/git repository (the default) where both `jj` and `git` commands work.
+
+2. **Change into the cloned directory**:
+   ```bash
+   cd <repo-name>
+   ```
+
+3. **Check which remote bookmarks exist**:
+   ```bash
+   jj bookmark list --all-remotes
+   ```
+
+4. **Track the default bookmark** (typically `main` or `master`):
+   ```bash
+   jj bookmark track main@origin
+   ```
+
+   Or if the repo uses `master`:
+   ```bash
+   jj bookmark track master@origin
+   ```
+
+   This creates a local bookmark that tracks the remote, so `jj git fetch` will update it.
+
+5. **Show the result**:
+   ```bash
+   jj log --limit 5
+   ```
+
+## Notes
+
+- By default, `jj git clone` creates a colocated repository where both jj and git commands work
+- The `trunk()` revset will automatically resolve to the tracked main/master bookmark
+- After cloning, you're on a new empty change with the default bookmark as its parent
+- Use `jj new` to start working, or just start editing files (changes are auto-tracked)
+
+## Example
+
+```
+/clone https://github.com/jj-vcs/jj
+```
+
+This will:
+1. Clone the jj repository
+2. Set up tracking for the main branch
+3. Leave you ready to start working

--- a/plugins/jjwf/commands/describe.md
+++ b/plugins/jjwf/commands/describe.md
@@ -1,0 +1,102 @@
+---
+description: Generate and set a description for the current jj change based on the diff
+---
+
+# Describe
+
+Generate a commit description from the current diff and apply it with `jj describe -m`, preserving any existing trailers and ID prefixes.
+
+## Workflow
+
+1. **Get the current description** (to check for existing content):
+   ```bash
+   jj log -r @ --ignore-working-copy --no-graph -T 'description'
+   ```
+
+2. **Get the current diff**:
+   ```bash
+   jj diff --git
+   ```
+
+3. **Parse the existing description** (if any):
+   - **ID prefix**: Check if the first line starts with an issue/ticket ID pattern like `ABC-123`, `PROJ-456`, `#123`, etc. These typically appear at the start of the first line, possibly followed by a colon or space.
+   - **Trailers**: Look for git-style trailers at the end of the message. Trailers are lines matching `Key: Value` or `Key #Value` format, like:
+     - `Co-authored-by: Name <email>`
+     - `Fixes #123`
+     - `Reviewed-by: Name`
+     - `Change-Id: I...`
+
+4. **Generate a new description** based on the diff:
+   - Summarize what changed in a clear, concise message
+   - Use imperative mood (e.g., "Add feature" not "Added feature")
+   - First line should be a brief summary
+
+5. **Compose the final description**:
+   - If there was an ID prefix, prepend it to the new first line (e.g., `ABC-123 Add new feature`)
+   - Add the generated description body
+   - If there were trailers, append them at the end (separated by a blank line)
+
+6. **Apply the description**:
+   ```bash
+   jj describe -m "Your composed message"
+   ```
+
+7. **Show the result**:
+   ```bash
+   jj log -r @ --ignore-working-copy
+   ```
+
+## Examples
+
+### Preserving an ID prefix
+
+Existing description:
+```
+ABC-123
+```
+
+After `/describe` with changes that add a login feature:
+```
+ABC-123 Add user login functionality
+```
+
+### Preserving trailers
+
+Existing description:
+```
+Some old description
+
+Co-authored-by: Alice <alice@example.com>
+Change-Id: I1234567890
+```
+
+After `/describe`:
+```
+Add new feature based on diff
+
+Co-authored-by: Alice <alice@example.com>
+Change-Id: I1234567890
+```
+
+### Preserving both
+
+Existing description:
+```
+PROJ-789 Old description
+
+Reviewed-by: Bob <bob@example.com>
+```
+
+After `/describe` with changes that fix a bug:
+```
+PROJ-789 Fix null pointer exception in parser
+
+Reviewed-by: Bob <bob@example.com>
+```
+
+## Notes
+
+- Common ID prefix patterns: `ABC-123`, `PROJ-456`, `#123`, `GH-123`
+- Common trailer keys: `Co-authored-by`, `Signed-off-by`, `Reviewed-by`, `Fixes`, `Closes`, `Change-Id`
+- If the diff is empty, inform the user there are no changes to describe
+- The `-m` flag is required to avoid opening an editor

--- a/plugins/jjwf/commands/pr.md
+++ b/plugins/jjwf/commands/pr.md
@@ -1,0 +1,136 @@
+---
+description: Prepare and push a pull request from mutable commits
+---
+
+# PR
+
+Interactive workflow to clean up mutable commits and create a pull request.
+
+## Workflow
+
+### Step 1: Review the current state
+
+First, check the current working copy and recent ancestors:
+
+```bash
+jj log -r '@:: | @- | @--' --ignore-working-copy
+```
+
+Also check the diff in the working copy:
+
+```bash
+jj diff --git
+```
+
+And list all mutable commits:
+
+```bash
+jj log -r 'mutable()' --ignore-working-copy --no-graph
+```
+
+### Step 2: Handle the working copy (@)
+
+Check if the working copy has changes:
+
+```bash
+jj diff --stat
+```
+
+If the working copy has changes but no description:
+- Check if @- is mutable: `jj log -r '@- & mutable()' --ignore-working-copy --no-graph`
+- If @- is mutable, ask: "Squash into parent, or add a description to @?"
+  - If squash: `jj squash` (squashes @ into @-)
+  - If describe: Generate a description based on the diff and run `jj describe -m "<message>"`
+
+If the working copy is empty (no changes), it will be handled in the next step.
+
+### Step 3: Handle empty commits
+
+Check for empty mutable commits:
+
+```bash
+jj log -r 'mutable() & empty()' --ignore-working-copy --no-graph
+```
+
+If there are empty commits, ask if they should be abandoned:
+
+```bash
+jj abandon 'mutable() & empty()'
+```
+
+### Step 4: Review @- and @--
+
+Check if @- and @-- are mutable and could be squashed:
+
+```bash
+jj log -r '(@- | @--) & mutable()' --ignore-working-copy --no-graph
+```
+
+If both @- and @-- are mutable non-empty commits, ask if the user wants to squash them together.
+
+If yes:
+```bash
+jj squash -r @- --into @--
+```
+
+Then generate a new description preserving any ID prefixes (like `ABC-123`) and trailers (like `Co-authored-by:`).
+
+### Step 5: Handle commits without descriptions
+
+Check for mutable commits without descriptions:
+
+```bash
+jj log -r 'mutable() & description(exact:"")' --ignore-working-copy --no-graph
+```
+
+For each commit without a description:
+- Show its diff: `jj diff -r <rev> --git`
+- Ask: "Generate a description, or squash into another commit?"
+- If generate: `jj describe -r <rev> -m "<generated message>"`
+- If squash and there's a parent to squash into: `jj squash -r <rev>`
+
+### Step 6: Consider squashing all mutable commits
+
+If there are multiple non-empty mutable commits remaining, ask if the user wants to squash them all into one:
+
+```bash
+jj squash --from 'mutable() ~ @' --into 'roots(mutable() ~ @)'
+```
+
+Generate a new combined description, preserving ID prefixes and trailers from existing descriptions.
+
+### Step 7: Push and create bookmark
+
+Determine which commit to push (the tip of mutable commits, excluding empty working copy):
+
+```bash
+jj log -r 'heads(mutable() ~ (@ & empty()))' --ignore-working-copy --no-graph -T 'change_id.short() ++ "\n"'
+```
+
+Push with auto-generated bookmark:
+
+```bash
+jj git push -c <change-id>
+```
+
+Note the bookmark name from the output (e.g., `push-abcdefgh`).
+
+### Step 8: Create pull request (optional)
+
+Ask if the user wants to create a pull request.
+
+If yes:
+
+```bash
+gh pr create --head <bookmark-name> --title "<title>" --body "<body>"
+```
+
+Use the commit description as the basis for the PR title (first line) and body (rest).
+
+## Notes
+
+- The `mutable()` revset includes all commits that aren't immutable
+- Always preserve ID prefixes (like `ABC-123`, `PROJ-456`) at the start of descriptions
+- Always preserve trailers (like `Co-authored-by:`, `Signed-off-by:`) at the end of descriptions
+- The `-c` flag on `jj git push` creates a bookmark for the specified revision
+- If push fails, inform the user and don't proceed to PR creation

--- a/plugins/jjwf/commands/squash.md
+++ b/plugins/jjwf/commands/squash.md
@@ -1,0 +1,33 @@
+---
+description: Squash the current jj change into its parent
+---
+
+# Squash
+
+Squash the current jj change into its parent commit.
+
+## Workflow
+
+1. **Check current state** (optional, for context):
+   ```bash
+   jj log -r @::@- --ignore-working-copy
+   ```
+
+2. **Run squash**:
+   ```bash
+   jj squash
+   ```
+
+   This moves all changes from the current commit into its parent.
+
+3. **Show the result**:
+   ```bash
+   jj log -r @ --ignore-working-copy
+   ```
+
+## Notes
+
+- `jj squash` without arguments squashes into the immediate parent
+- If the parent has a description and the current commit doesn't, the parent's description is preserved
+- If both have descriptions, use `-m "message"` to provide a combined message, or `-u` to keep the destination's message
+- After squashing, the current change becomes empty and you'll be working on the (now modified) parent

--- a/plugins/jjwf/skills/jjwf/SKILL.md
+++ b/plugins/jjwf/skills/jjwf/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: jjwf
+description: Jujutsu (jj) workflow skill. This skill should be used when the project uses jj for version control instead of git. Provides guidance on using jj commands and references the jj-vcs skill for detailed documentation.
+---
+
+# Jujutsu (jj) Workflow
+
+This project uses Jujutsu (jj) for version control instead of git.
+
+## Key Differences from Git
+
+- **No staging area**: All changes in the working directory are automatically part of the current change
+- **Changes vs commits**: jj uses "changes" (identified by change IDs) rather than commits
+- **Automatic snapshots**: The working copy is automatically snapshotted
+- **Immutable history**: By default, only "mutable" commits can be modified
+
+## Common Workflow Commands
+
+| Task | Command |
+|------|---------|
+| See current status | `jj status` |
+| View diff | `jj diff --git` |
+| Commit current change | `jj ci -m "message"` or `jj commit -m "message"` |
+| Set/update description | `jj describe -m "message"` |
+| Squash into parent | `jj squash` |
+| Create new change | `jj new` |
+| Push to remote | `jj git push` |
+| Fetch from remote | `jj git fetch` |
+
+## Agent Guidelines
+
+When working in this repository:
+
+1. **Use jj, not git**: All version control operations should use jj commands
+2. **Always use `-m` flag**: For `jj describe`, `jj commit`, and `jj squash` to avoid opening an editor
+3. **Use `--ignore-working-copy`**: For read operations like `jj log` and `jj diff` when you don't need the latest snapshot
+4. **Use `--git` for diffs**: `jj diff --git` produces standard unified diff format
+
+## For More Information
+
+For detailed jj documentation, command references, revset syntax, and templates, invoke the `/jj` command or reference the jj-vcs skill.


### PR DESCRIPTION
Adds new jjwf plugin with workflow commands for jj version control:

- `/ci` - Commit with auto-generated message
- `/describe` - Update description (preserves ID prefixes and trailers)
- `/squash` - Squash into parent
- `/catchup` - Fetch and rebase onto trunk
- `/clone` - Clone repo and track default bookmark
- `/pr` - Clean up mutable commits and create a pull request

Also adds `/gist` command to chores plugin for creating GitHub gists.